### PR TITLE
Suggested changes to How-we-manage-the-standard

### DIFF
--- a/en/how-we-manage-the-standard.rst
+++ b/en/how-we-manage-the-standard.rst
@@ -18,21 +18,20 @@ The IATI standard is a living entity that will require improvement over time.
 
 The standard is a collection of XML schema, core codelists, non-core codelists, documentation and rules.
 
-Changes to some or all of those parts of the standard will be driven by the suggestions and experiences of the publishers and users of IATI data. Minor (previously decimal) upgrades can be initiated by the `Governing Board <https://iatistandard.org/en/about/governance/who-runs-iati/>`__, following advice from the TAG Chair and the Technical Lead. Major upgrades can be initiated by the `Members’ Assembly <https://iatistandard.org/en/about/join-iati/members-assembly/>`__, following the advice from the Governing Board.
+Changes to some or all of those parts of the standard will be driven by the suggestions and experiences of the publishers and users of IATI data. Depending on what changes are being proposed, the following processes will be followed:
 
-Any member of the IATI community can make a proposal (via `IATI Discuss <https://discuss.iatistandard.org/c/standard-management>`__), and each upgrade process will receive its own forum where proposals can be assigned. The forums allow for a public exchange on the merits of the proposals to take place.
-
+Upgrade process: Minor (previously decimal) upgrades can be initiated by the `Governing Board <https://iatistandard.org/en/about/governance/who-runs-iati/>`__, following advice from the TAG Chair and the Technical Lead. Major upgrades can be initiated by the `Members’ Assembly <https://iatistandard.org/en/about/join-iati/members-assembly/>`__, following the advice from the Governing Board.
 The current process for upgrading the standard (details below) was agreed at the `2017 Members’ Assembly <https://iatistandard.org/documents/242/Paper-10-Proposed-revisions-to-the-IATI-Standard-upgrade-process.pdf>`__. For the previous upgrade process please see the `Previous Upgrade Process <http://iatistandard.org/upgrades/all-versions/previous-process>`__ page.
 
-Details of how the IATI codelists are managed are here (add in link).
+For information about different versions of the **IATI Standard** see :doc:`All versions <how-we-manage-the-standard/versions>`. 
 
-Note: The current standard upgrade process will follow the widely-adopted `Semantic Versioning specification <https://semver.org/>`__ at the next major upgrade.
+Codelist changes: There are different types of codelist changes. Details of how the IATI codelists are managed are here (add in link).
 
-Considerations
---------------
 
-* For information about different versions of the **IATI Standard** see :doc:`All versions <how-we-manage-the-standard/versions>`. 
-* Documentation on previous versions is freely available.
-* Suggestions for changes and enhancements across the Standard are accepted from all stakeholders.
-* Planned changes are advertised well in advance.
-* Publishers can chose which version of the standard they wish to meet.
+How to get involved and suggest changes: Any member of the IATI community can make a proposal (via `IATI Discuss <https://discuss.iatistandard.org/c/standard-management>`__). Suggestions for changes and enhancements across the Standard are accepted from all stakeholders. Each proposal will be assigned to the relevant category under Stanard Management.The forums allow for a public exchange on the merits of the proposals to take place.
+
+If you have any questions about the standard management processes, please do get in touch by emailing our Helpdesk (support@iatistandard.org)
+
+
+
+


### PR DESCRIPTION
Hi @amy-silcock  I made some suggestions. Am I correct that this page is basically the parent page/ overview page and the the child pages will be:
codelist-management.rst	
previous-process.rst	
upgrade-process.rst	
versions.rst

I basically tried to structure the page in a way so that it gives an overview and then we can link to child pages, without duplicating content too much.

I have also removed the below as I don't see them as consideration or notes we need to add. Unless you have pulled them from existing content on the reference site?
* Documentation on previous versions is freely available.
* Planned changes are advertised well in advance.
* Publishers can chose which version of the standard they wish to meet.